### PR TITLE
fix: Handle errors from NetworkInformation

### DIFF
--- a/Raygun4UWP/Common/HttpService.cs
+++ b/Raygun4UWP/Common/HttpService.cs
@@ -66,12 +66,20 @@ namespace Raygun4UWP
 
     private static void UpdateIsInternetAvailable()
     {
-      IEnumerable<ConnectionProfile> connections = NetworkInformation.GetConnectionProfiles();
-      var internetProfile = NetworkInformation.GetInternetConnectionProfile();
+      try
+      {
+        IEnumerable<ConnectionProfile> connections = NetworkInformation.GetConnectionProfiles();
+        var internetProfile = NetworkInformation.GetInternetConnectionProfile();
 
-      _isInternetAvailable = connections != null && connections.Any(c =>
-                               c.GetNetworkConnectivityLevel() == NetworkConnectivityLevel.InternetAccess) ||
-                             (internetProfile != null && internetProfile.GetNetworkConnectivityLevel() == NetworkConnectivityLevel.InternetAccess);
+        _isInternetAvailable = connections != null && connections.Any(c =>
+                                 c.GetNetworkConnectivityLevel() == NetworkConnectivityLevel.InternetAccess) ||
+                               (internetProfile != null && internetProfile.GetNetworkConnectivityLevel() == NetworkConnectivityLevel.InternetAccess);
+      }
+      catch (Exception)
+      {
+        // If we can't determine the internet status, assume it's not available
+        _isInternetAvailable = false;
+      }
     }
   }
 }


### PR DESCRIPTION
Capture any errors from `NetworkInformation.GetConnectionProfiles()` and assume Internet is not available if those happen.

Fixes https://raygun.com/forums/thread/186968#186999